### PR TITLE
Add expectElement support for both count and contains

### DIFF
--- a/test-support/helpers/201-created/raw/expect-element.js
+++ b/test-support/helpers/201-created/raw/expect-element.js
@@ -4,15 +4,16 @@ function filterElements(elements, text){
   return elements.filter(':contains(' + text + ')');
 }
 
-export default function(app, selector, options){
-  var count;
-
-  if (typeof options === 'number') {
-    count   = options;
-    options = {count:count};
+export default function(app, selector, count, options){
+  if (typeof count === 'object') {
+    options = count;
   }
 
   if (!options) { options = {}; }
+  
+  if (typeof count === 'number') {
+    options.count = count;
+  }
 
   count = options.count === undefined ? 1 : options.count;
 

--- a/tests/unit/expect-element-test.js
+++ b/tests/unit/expect-element-test.js
@@ -117,6 +117,24 @@ test('takes option `contains`', function(){
   equal(result.message, 'Found 1 of .the-div but 0/1 containing "not found"');
 });
 
+test('can be passed a number and option `contains`', function(){
+  var find = function(){
+    return makeElements('div', {class:'the-div', text: 'foo bar'}, 3);
+  };
+
+  var app = makeApp(find);
+
+  var result = expectElement(app, '.the-div', 3, {contains:'foo'});
+
+  ok(result.ok, 'passes');
+  equal(result.message, 'Found 3 of .the-div containing "foo"');
+
+  result = expectElement(app, '.the-div', 3, {contains:'not found'});
+
+  ok(!result.ok, 'fails');
+  equal(result.message, 'Found 3 of .the-div but 0/3 containing "not found"');
+});
+
 test('option `contains` filters the elements', function(){
   var find = function(){
     return $([


### PR DESCRIPTION
I noticed while trying to incorporate your helpers that `expectElement` didn’t support both a count and a text matcher. Was that intentional? If not, this fixes that.
