### PR TITLE
Add link to Mocha fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ A convenience for `expectElement` when the count is 0.
 
 `options` can include a `contains` key.
 
+## Mocha
+
+If you want to use this with [`ember-cli-mocha`](https://github.com/switchfly/ember-cli-mocha), try [this fork](https://github.com/backspace/ember-cli-acceptance-test-helpers/tree/use-mocha).
+
 ## Setup
 
   * Run `ember generate ember-cli-acceptance-test-helpers`


### PR DESCRIPTION
As you suggested in #7. I can move it if you think it’s better placed elsewhere.
