### PR TITLE
Define expectNoElement in terms of expectElement and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,5 @@ The generator makes changes to files assuming the structure of them has not chan
 
  * clickLink
  * test/document `hasClass` option
- * ensure that `expectNoElement(selector, {contains:text}) works`
  * a `within(selector/component, block&)` helper
  * every expectation only adds 1 expectation, so it's easy to use `expect(X)`

--- a/test-support/helpers/201-created/raw/expect-no-element.js
+++ b/test-support/helpers/201-created/raw/expect-no-element.js
@@ -1,14 +1,10 @@
 import {getContext} from '../utils/helper-context';
+import expectElement from './expect-element';
 
 export default function(app, selector, options, message){
   if (!options) {
     options = {};
   }
 
-  var element = app.testHelpers.find(selector, getContext());
-
-  return {
-    ok: element.length === 0,
-    message: message || 'Expected to find 0 instances of ' + selector
-  };
+  return expectElement(app, selector, 0, options);
 }

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -41,6 +41,7 @@ test('visiting /, expectNoElement', function() {
 
   andThen(function() {
     App.testHelpers.expectNoElement('.missing-div');
+    App.testHelpers.expectNoElement('h2', {contains: 'there'});
   });
 });
 

--- a/tests/unit/expect-no-element-test.js
+++ b/tests/unit/expect-no-element-test.js
@@ -1,0 +1,79 @@
+import {
+  test
+} from 'ember-qunit';
+
+import expectNoElement from '../helpers/201-created/raw/expect-no-element';
+
+module('Unit - expectNoElement');
+
+test('expectNoElement exists', function(){
+  ok(expectNoElement, 'it exists');
+});
+
+function makeElement(elementType, options){
+  var el = $(document.createElement(elementType));
+  if (options.class) { el.addClass('class', options.class); }
+  if (options.text)  { el.text(options.text); }
+
+  return el.get(0);
+}
+
+function makeElements(elementType, options, count){
+  var els = [];
+  for (var i = 0; i < count; i++) {
+    els.push(makeElement(elementType, options));
+  }
+
+  return $(els);
+}
+
+function makeApp(findFn){
+  return {
+    testHelpers: { find: findFn },
+    $: $
+  };
+}
+
+test('passes when the element is not found by app.testHelpers.find', function(){
+  var find = function(){
+    return [];
+  };
+
+  var app = makeApp(find);
+
+  var result = expectNoElement(app, '.the-div');
+
+  ok(result.ok, 'passes');
+  equal(result.message, 'Found 0 of .the-div');
+});
+
+test('fails when the element is found by app.testHelpers.find', function(){
+  var find = function(){
+    return [makeElement('div', {class:'the-div'})];
+  };
+
+  var app = makeApp(find);
+
+  var result = expectNoElement(app, '.the-div');
+
+  ok(!result.ok, 'fails');
+  equal(result.message, 'Found 1 of .the-div but expected 0');
+});
+
+test('takes option `contains`', function(){
+  var find = function(){
+    return makeElements('div', {class:'the-div', text: 'foo bar'}, 1);
+  };
+
+  var app = makeApp(find);
+
+  var result = expectNoElement(app, '.the-div', {contains:'boo'});
+
+  ok(result.ok, 'passes');
+  equal(result.message, 'Found 0 of .the-div containing "boo"');
+
+  result = expectNoElement(app, '.the-div', {contains:'foo'});
+
+  ok(!result.ok, 'fails');
+  equal(result.message, 'Found 1 of .the-div containing "foo" but expected 0');
+});


### PR DESCRIPTION
You have this line in the README:
- ensure that expectNoElement(selector, {contains:text}) works

I found today that it doesn’t.

This change defines `expectNoElement(selector, options)` as an actual convenience method for `expectElement(selector, 0, options)`, adds tests to ensure functionality, and removes that line from the README.

Maybe you defined it differently because you wanted `expectNoElement`-specific failure messages, but it seemed sensible to me to just reuse the existing code rather than define a helper with most of the same functionality.
