### PR TITLE
Reset context after withinElement

### DIFF
--- a/test-support/helpers/201-created/utils/within-element.js
+++ b/test-support/helpers/201-created/utils/within-element.js
@@ -1,8 +1,10 @@
-import {setContext} from './helper-context';
+import {getContext, setContext} from './helper-context';
 
 export default function(app, selector, callback){
   var elements = app.testHelpers.find(selector);
 
+  var previousContext = getContext();
   setContext( elements[0] );
   callback();
+  setContext( previousContext );
 }

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -53,5 +53,7 @@ test('visiting /, withinElement', function() {
       App.testHelpers.expectElement('.inner-div');
       App.testHelpers.expectNoElement('.outer-div');
     });
+
+    App.testHelpers.expectElement('h2');
   });
 });


### PR DESCRIPTION
I know it’s an undocumented helper, but it would be helpful in my tests to reduce verbosity. It was mostly working, but not resetting the context after the `withinElement` callback completed. I added a test that verifies that an `expectElement` after a `withinElement` now works.

I could add it to the documentation if you think it’s ready to be public.