### PR TITLE
1.13.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
   "name": "ember-cli-acceptance-test-helpers",
   "dependencies": {
-    "ember": "1.12.0",
+    "ember": "1.13.2",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.0.0-beta.18",
+    "ember-data": "1.13.2",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.13",
     "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.0.0-beta.18",
+    "ember-data": "1.13.2",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",

--- a/test-support/helpers/201-created/utils/each-view.js
+++ b/test-support/helpers/201-created/utils/each-view.js
@@ -27,7 +27,12 @@ function iterateViews(callback, callbackHistory){
 }
 
 export default function(app, callback){
-  var allViews = Ember.View.views;
+  var allViews = app.__container__.lookup('-view-registry:main');
+
+  if ( ! allViews ) { // Ember 1.11.0 compatibility
+    allViews = Ember.View.views;
+  } 
+ 
   var views = Object.keys(allViews).map(function(viewName) {
     return allViews[viewName];
   });


### PR DESCRIPTION
(Depeneds on https://github.com/201-created/ember-cli-acceptance-test-helpers/pull/19)

The tests fail in Ember 1.13.2 with:

```
message: >
            TypeError: Requested keys of a value that is not an object.
```

It happens because `Ember.View.view` is undefined, I placed a TODO.
So, do you have any ideas of how I could replace that line? 