### PR TITLE
Remove lodash dependency

### DIFF
--- a/blueprints/ember-cli-acceptance-test-helpers/index.js
+++ b/blueprints/ember-cli-acceptance-test-helpers/index.js
@@ -35,10 +35,6 @@ module.exports = {
             // .jshintrc file
             .then( function() {
                 return this.insertIntoFile( thirdFile, thirdText, { after: thirdLocationText } );
-            }.bind(this))
-
-            .then( function() {
-              return this.addBowerPackageToProject('lodash', '3.9.3');
             }.bind(this));
     },
 

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1",
-    "lodash": "~3.9.3"
+    "qunit": "~1.17.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,9 +2,5 @@
 'use strict';
 
 module.exports = {
-  included: function(app) {
-    app.import('bower_components/lodash/lodash.js');
-  },
-
   name: 'ember-cli-acceptance-test-helpers'
 };

--- a/test-support/helpers/201-created/utils/each-view.js
+++ b/test-support/helpers/201-created/utils/each-view.js
@@ -17,8 +17,7 @@ function iterateViews(callback, callbackHistory){
     if (state !== 'inDOM') { return; }
     */
 
-    if ( ! _.includes(callbackHistory, view) )
-    {
+    if (callbackHistory.indexOf(view) === -1) {
       callback(view);
       callbackHistory.push(view);
     }


### PR DESCRIPTION
removes lodash dependency since it is only used in one spot for an `indexOf`