### PR TITLE
Demonstrate failure of expectComponent in ember 1.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,3 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
-*~
-*#*#

--- a/.npmignore
+++ b/.npmignore
@@ -10,5 +10,6 @@ dist/
 .npmignore
 **/.gitkeep
 bower.json
+ember-cli-build.js
 Brocfile.js
 testem.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1.11.0
-  - EMBER_TRY_SCENARIO=ember-1.12.0
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -20,7 +18,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Ember Test Helpers
+# Ember-cli-acceptance-test-helpers
 
 A set of useful helper for ember-cli acceptance tests. Includes
 `expectComponent`, `expectElement`, and `clickComponent`.
@@ -93,3 +94,4 @@ If you have errors running `npm adduser`, you may have previously set your npm r
  * test/document `hasClass` option
  * a `within(selector/component, block&)` helper
  * every expectation only adds 1 expectation, so it's easy to use `expect(X)`
+For more information on using ember-cli, visit [http://www.ember-cli.com/](http://www.ember-cli.com/).

--- a/bower.json
+++ b/bower.json
@@ -1,16 +1,19 @@
 {
   "name": "ember-cli-acceptance-test-helpers",
   "dependencies": {
-    "ember": "1.13.2",
+    "ember": "1.13.3",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.2",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
-    "ember-qunit": "0.3.3",
+    "ember-data": "1.13.5",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
+    "ember-qunit": "0.4.1",
     "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.15",
+    "ember-resolver": "~0.1.18",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1"
+  },
+  "resolutions": {
+    "ember-data": "1.13.5"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,0 +1,17 @@
+/* global require, module */
+var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
+
+module.exports = function(defaults) {
+  var app = new EmberApp(defaults, {
+    // Add options here
+  });
+
+  /*
+    This build file specifes the options for the dummy test app of this
+    addon, located in `/tests/dummy`
+    This build file does *not* influence how the addon or the app using it
+    behave. You most likely want to be modifying `./index.js` or app's build file
+  */
+
+  return app.toTree();
+};

--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-htmlbars": "0.7.9",
-    "ember-cli-htmlbars-inline-precompile": "^0.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.15",
     "ember-cli-release": "0.2.3",
     "ember-cli-uglify": "^1.0.1",
     "ember-data": "1.13.5",
+    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
-    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-try": "0.0.6"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ember-cli-acceptance-test-helpers",
   "main": "index.js",
   "version": "0.3.5",
+  "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -15,24 +16,26 @@
   "engines": {
     "node": ">= 0.10.0"
   },
-  "author": "Cory Forsyth",
+  "author": "",
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "0.2.7",
-    "ember-cli-app-version": "0.3.3",
+    "ember-cli": "1.13.1",
+    "ember-cli-app-version": "0.4.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
-    "ember-cli-htmlbars": "0.7.6",
-    "ember-cli-ic-ajax": "0.1.1",
+    "ember-cli-htmlbars": "0.7.9",
+    "ember-cli-htmlbars-inline-precompile": "^0.1.1",
+    "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.13",
+    "ember-cli-qunit": "0.3.15",
+    "ember-cli-release": "0.2.3",
     "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.13.2",
-    "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-data": "1.13.5",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
-    "ember-try": "0.0.7"
+    "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-try": "0.0.6"
   },
   "keywords": [
     "ember-addon"

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -26,7 +26,7 @@
   "node": false,
   "browser": false,
   "boss": true,
-  "curly": false,
+  "curly": true,
   "debug": false,
   "devel": false,
   "eqeqeq": true,
@@ -47,5 +47,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true
+  "esnext": true,
+  "unused": true
 }

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -43,7 +43,7 @@ test('visiting /, expectComponent', function(assert) {
   });
 });
 
-test('visiting /, expectElement', function(assert) {
+test('visiting /, expectElement', function(/*assert*/) {
   visit('/');
 
   andThen(function() {
@@ -51,7 +51,7 @@ test('visiting /, expectElement', function(assert) {
   });
 });
 
-test('visiting /, expectNoElement', function(assert) {
+test('visiting /, expectNoElement', function(/*assert*/) {
   visit('/');
 
   andThen(function() {
@@ -60,7 +60,7 @@ test('visiting /, expectNoElement', function(assert) {
   });
 });
 
-test('visiting /, withinElement', function(assert) {
+test('visiting /, withinElement', function(/*assert*/) {
   visit('/');
 
   andThen(function() {

--- a/tests/integration/expect-component-hbs-integration-test.js
+++ b/tests/integration/expect-component-hbs-integration-test.js
@@ -16,7 +16,7 @@ moduleForComponent('simple-component', {
   integration: true
 });
 
-test('finds component in hbs integration test', function(assert) {
+test('finds root component in hbs integration test', function(assert) {
   this.render(hbs`{{simple-component}}`);
 
   andThen(function() {
@@ -33,3 +33,13 @@ test('does not find component when not present in hbs integration test', functio
     assert.ok(!result.ok, "expected a failure");
 	});
 });
+
+test('finds inner component in hbs integration test', function(assert) {
+  this.render(hbs`{{compound-component}}`);
+
+  andThen(function() {
+	  var result = expectComponent(App, 'simple-component', 1);
+    assert.ok(result.ok, "expected success");
+	});
+});
+

--- a/tests/integration/expect-component-hbs-integration-test.js
+++ b/tests/integration/expect-component-hbs-integration-test.js
@@ -1,0 +1,35 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import expectComponent from '../helpers/201-created/raw/expect-component';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+var App;
+
+moduleForComponent('simple-component', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  },
+  integration: true
+});
+
+test('finds component in hbs integration test', function(assert) {
+  this.render(hbs`{{simple-component}}`);
+
+  andThen(function() {
+	  var result = expectComponent(App, 'simple-component', 1);
+    assert.ok(result.ok, "expected success");
+	});
+});
+
+test('does not find component when not present in hbs integration test', function(assert) {
+  this.render(hbs`{{another-component}}`);
+
+  andThen(function() {
+	  var result = expectComponent(App, 'simple-component', 1);
+    assert.ok(!result.ok, "expected a failure");
+	});
+});


### PR DESCRIPTION
Upgraded addon to ember 1.13
Added component integration tests to show `expectComponent` doesn't work
This demonstrates issue #22