### PR TITLE
Add optional message to expectElement and expectNoElement

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-acceptance-test-helpers",
   "dependencies": {
-    "ember": "1.13.7",
+    "ember": "1.13.13",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.17.1"
   }

--- a/test-support/helpers/201-created/raw/expect-element.js
+++ b/test-support/helpers/201-created/raw/expect-element.js
@@ -10,10 +10,11 @@ export default function(app, selector, count, options){
   }
 
   if (!options) { options = {}; }
-  
+
   if (typeof count === 'number') {
     options.count = count;
   }
+  // debugger;
 
   count = options.count === undefined ? 1 : options.count;
 
@@ -21,7 +22,11 @@ export default function(app, selector, count, options){
 
   var result = {};
 
+  // options
+  // {message: whatever, contains: thka}
+
   if (options.contains) {
+    // why is options.contains false
     var text = options.contains;
     var filtered = filterElements(elements, text);
 
@@ -40,10 +45,24 @@ export default function(app, selector, count, options){
       }
     }
   } else {
-    result.message = 'Found ' + elements.length + ' of ' + selector;
+    // i'm erroring here
+    // want result.message = result.message; ...but this isn't really anything
+
     result.ok = elements.length === count;
-    if (!result.ok) {
-      result.message += ' but expected ' + count;
+
+    // move message to a helper
+
+    if (options.message) {
+      let message = options.message;
+      result.message = message;
+    }
+    else {
+      result.message = 'Found ' + elements.length + ' of ' + selector;
+
+      if (!result.ok) {
+        // and here
+        result.message += ' but expected ' + count;
+      }
     }
   }
 

--- a/tests/helpers/element-helpers.js
+++ b/tests/helpers/element-helpers.js
@@ -1,0 +1,25 @@
+export function makeElement(elementType, options){
+  var el = $(document.createElement(elementType));
+  if (options.class) { el.addClass('class', options.class); }
+  if (options.text)  { el.text(options.text); }
+
+  return el.get(0);
+}
+
+export function makeElements(elementType, options, count){
+  var els = [];
+  for (var i = 0; i < count; i++) {
+    els.push(makeElement(elementType, options));
+  }
+
+  return $(els);
+}
+
+export function makeApp(findFn){
+  return {
+    testHelpers: {
+      find: (...args) => $(findFn(...args))
+    },
+    $: $
+  };
+}

--- a/tests/unit/expect-element-test.js
+++ b/tests/unit/expect-element-test.js
@@ -153,3 +153,29 @@ test('option `contains` filters the elements', function(assert) {
   assert.ok(!result.ok, 'fails');
   assert.equal(result.message, 'Found 2 of .the-div but 0/1 containing "not found"');
 });
+
+test('expectElement fails with a custom message', function(assert) {
+  let app = makeApp(() => []);
+  let message = 'custom test label message';
+
+  // {message: message}
+  let result = expectElement(app, '.not-present', {message});
+
+  assert.ok(!result.ok, 'pre cond: fails');
+  assert.equal(result.message, message, 'custom message appears on expectElement fail');
+});
+
+test('expectElement passes with a custom message', function(assert) {
+  let find = function(){
+    return [makeElement('div', {class:'the-div'})];
+  };
+
+  let app = makeApp(find);
+  let message = 'custom test label message';
+
+  let result = expectElement(app, '.is-present', {message});
+  // debugger;
+  assert.ok(result.ok, 'pre cond: passes');
+
+  assert.equal(result.message, message, 'custom message appears on expectElement pass');
+});

--- a/tests/unit/expect-element-test.js
+++ b/tests/unit/expect-element-test.js
@@ -1,36 +1,17 @@
 import { module } from 'qunit';
 import { test } from 'ember-qunit';
 import expectElement from '../helpers/201-created/raw/expect-element';
+import {
+  makeElement,
+  makeElements,
+  makeApp
+} from '../helpers/element-helpers';
 
 module('Unit - expectElement');
 
 test('expectElement exists', function(assert) {
   assert.ok(expectElement, 'it exists');
 });
-
-function makeElement(elementType, options){
-  var el = $(document.createElement(elementType));
-  if (options.class) { el.addClass('class', options.class); }
-  if (options.text)  { el.text(options.text); }
-
-  return el.get(0);
-}
-
-function makeElements(elementType, options, count){
-  var els = [];
-  for (var i = 0; i < count; i++) {
-    els.push(makeElement(elementType, options));
-  }
-
-  return $(els);
-}
-
-function makeApp(findFn){
-  return {
-    testHelpers: { find: findFn },
-    $: $
-  };
-}
 
 test('passes when the element is found by app.testHelpers.find', function(assert) {
   var find = function(){
@@ -135,10 +116,10 @@ test('can be passed a number and option `contains`', function(assert) {
 
 test('option `contains` filters the elements', function(assert) {
   var find = function(){
-    return $([
+    return [
       makeElement('div', {class:'the-div'}),
       makeElement('div', {class:'the-div', text: 'foo bar'})
-    ]);
+    ];
   };
 
   var app = makeApp(find);
@@ -157,9 +138,7 @@ test('option `contains` filters the elements', function(assert) {
 test('expectElement fails with a custom message', function(assert) {
   let app = makeApp(() => []);
   let message = 'custom test label message';
-
-  // {message: message}
-  let result = expectElement(app, '.not-present', {message});
+  let result = expectElement(app, '.is-not-present', {message});
 
   assert.ok(!result.ok, 'pre cond: fails');
   assert.equal(result.message, message, 'custom message appears on expectElement fail');
@@ -172,10 +151,17 @@ test('expectElement passes with a custom message', function(assert) {
 
   let app = makeApp(find);
   let message = 'custom test label message';
-
   let result = expectElement(app, '.is-present', {message});
-  // debugger;
-  assert.ok(result.ok, 'pre cond: passes');
 
+  assert.ok(result.ok, 'pre cond: passes');
   assert.equal(result.message, message, 'custom message appears on expectElement pass');
+});
+
+test('expectElement with contains fails with a custom message', function(assert) {
+  let app = makeApp(() => []);
+  let message = 'custom test label message';
+  let result = expectElement(app, '.is-not-present', {contains: 'foo', message});
+
+  assert.ok(!result.ok, 'pre cond: fails');
+  assert.equal(result.message, message, 'custom message appears on expectElement fail');
 });

--- a/tests/unit/expect-no-element-test.js
+++ b/tests/unit/expect-no-element-test.js
@@ -1,36 +1,17 @@
 import { module} from 'qunit';
 import { test } from 'ember-qunit';
 import expectNoElement from '../helpers/201-created/raw/expect-no-element';
+import {
+  makeElement,
+  makeElements,
+  makeApp
+} from '../helpers/element-helpers';
 
 module('Unit - expectNoElement');
 
 test('expectNoElement exists', function(assert) {
   assert.ok(expectNoElement, 'it exists');
 });
-
-function makeElement(elementType, options){
-  var el = $(document.createElement(elementType));
-  if (options.class) { el.addClass('class', options.class); }
-  if (options.text)  { el.text(options.text); }
-
-  return el.get(0);
-}
-
-function makeElements(elementType, options, count){
-  var els = [];
-  for (var i = 0; i < count; i++) {
-    els.push(makeElement(elementType, options));
-  }
-
-  return $(els);
-}
-
-function makeApp(findFn){
-  return {
-    testHelpers: { find: findFn },
-    $: $
-  };
-}
 
 test('passes when the element is not found by app.testHelpers.find', function(assert) {
   var find = function(){
@@ -74,4 +55,34 @@ test('takes option `contains`', function(assert) {
 
   assert.ok(!result.ok, 'fails');
   assert.equal(result.message, 'Found 1 of .the-div containing "foo" but expected 0');
+});
+
+test('expectNoElement fails with a custom message', function(assert) {
+  let find = function(){
+    return [makeElement('div', {class:'the-div'})];
+  };
+  let app = makeApp(find);
+  let message = 'custom test label message';
+  let result = expectNoElement(app, '.is-not-present', {message});
+
+  assert.ok(!result.ok, 'pre cond: fails');
+  assert.equal(result.message, message, 'custom message appears on expectElement fail');
+});
+
+test('expectNoElement passes with a custom message', function(assert) {
+  let app = makeApp(() => []);
+  let message = 'custom test label message';
+  let result = expectNoElement(app, '.is-not-present', {message});
+
+  assert.ok(result.ok, 'pre cond: passes');
+  assert.equal(result.message, message, 'custom message appears on expectNoElement pass');
+});
+
+test('expectNoElement with contains passes with a custom message', function(assert) {
+  let app = makeApp(() => []);
+  let message = 'custom test label message';
+  let result = expectNoElement(app, '.is-present', {contains: 'foo', message});
+
+  assert.ok(result.ok, 'pre cond: passes');
+  assert.equal(result.message, message, 'custom message appears on expectNoElement fail');
 });


### PR DESCRIPTION
* add message to options hash, so can identify `expectElement` or `expectNoElement` test with a custom name, similar to `assert.ok(find('something'), 'my custom test name here')`
* updated ember due to to error message on ember test:

```
Future versions of Ember CLI will not support v4.2.3. Please update to Node 0.12 or io.js.
version: 1.13.8
Invalid watchman found, version: [4.4.0] did not satisfy [^3.0.0], falling back to NodeWatcher.
Visit http://www.ember-cli.com/user-guide/#watchman for more info.
```

* make buildMessage into a helper function
* extract test helpers to be DRY
* completes https://github.com/201-created/ember-cli-acceptance-test-helpers/issues/26 and https://github.com/zestyzesty/hack-day/issues/9
* paired w @mixonic 