### PR TITLE
support expecting zero component instances

### DIFF
--- a/test-support/helpers/201-created/raw/expect-component.js
+++ b/test-support/helpers/201-created/raw/expect-component.js
@@ -1,5 +1,8 @@
 import {lookupComponent} from '../utils/lookup';
 import eachView from '../utils/each-view';
+import Ember from 'ember';
+
+const { isPresent } = Ember;
 
 var K = function(){};
 
@@ -36,12 +39,12 @@ export default function(appOrContainer, expectation, count, options, customMessa
     }
   });
 
-  var message = count ? 
-                'Expected to find '+count+' components of type ' + expectation + '. Found: ' + found : 
+  var message = count ?
+                'Expected to find '+count+' components of type ' + expectation + '. Found: ' + found :
                 'Expected to find at least one component: ' + expectation;
 
   var result = {
-    ok: count ? found === count : found > 0, // if count specified then we must have exactly that many, otherwise we want at least 1
+    ok: isPresent(count) ? found === count : found > 0, // if count specified then we must have exactly that many, otherwise we want at least 1
     message: customMessage || message
   };
 

--- a/tests/acceptance/expect-component-test.js
+++ b/tests/acceptance/expect-component-test.js
@@ -145,4 +145,13 @@ test('expectComponent gives component missing error when component is not presen
   });
 });
 
+test('expectComponent supports expecting zero component instances', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    var result = expectComponent(App, 'another-component', 0);
+    assert.ok(result.ok, "expected a failure");
+  });
+});
+
 // 'fails is the component is found but destroyed'


### PR DESCRIPTION
Before a count of zero was the same as expecting at least one instance.
I don't think this was expected behaivor and can't imagine someone used that by purpose.